### PR TITLE
Added topicwizard, turftopic, tweetopic and stormtrooper

### DIFF
--- a/repos.jsonl
+++ b/repos.jsonl
@@ -20,3 +20,7 @@
 {"repo": "adriangb/scikeras", "pypi": "scikeras"}
 {"repo": "scikit-learn-contrib/category_encoders", "pypi": "category_encoders"}
 {"repo": "scikit-multilearn/scikit-multilearn", "pypi": "scikit-multilearn"}
+{"repo": "x-tabdeveloping/topicwizard", "pypi": "topic-wizard"}
+{"repo": "x-tabdeveloping/turftopic", "pypi": "turftopic"}
+{"repo": "centre-for-humanities-computing/tweetopic", "pypi": "tweetopic"}
+{"repo": "centre-for-humanities-computing/stormtrooper", "pypi": "stormtrooper"}


### PR DESCRIPTION
Added my libraries built around the scikit-learn API:
 - topicwizard: A topic model interpretation and visualization library built mainly around scikit-learn pipelines containing a vectorizer and a topic model (e.g. LSA, NMF)
 - Turftopic: A topic modeling library for contextually sensitive topic modeling with sentence-transformers. Contains clustering topic models (BERTopic, Top2Vec), Autoencoding topic models (CTM), and three novel topic models we have developed. Every model is a `TransformerMixin`, and can be readily used in scikit-learn workflows.
 - tweetopic is a fast Numba implementation of two short-text topic models (Dirichlet Multinomial Mixtures, Biterm Topic Models), both of which were designed to be used primarily as part of a topic pipeline in scikit-learn.
 - stormtrooper is a zero-, and few-shot classification library using SetFit, NLI and generative language models and is built around the scikit-learn API